### PR TITLE
Hotfix for Minecraft server offline detection

### DIFF
--- a/mainari.py
+++ b/mainari.py
@@ -43,6 +43,12 @@ class Mainari:
     def parseServerData(self, data):
         server_is_offline = not 'online' in data
 
+        # Due to API changes the server can also be offline if it has
+        # the 'online' key with a value of False
+        if 'online' in data:
+            if data['online'] == False:
+                server_is_offline = True
+
         # Data gathered if the server is offline
         if server_is_offline:
             server_status_msg = 'OFFLINE'
@@ -50,7 +56,7 @@ class Mainari:
         # Data gathered if the server is online
         else:
             server_status_msg = 'Online'
-            motd = data['motd']['raw'][0]
+            motd = data['motd']['clean'][0]
             players = data['players']['online']
             players_max = data['players']['max']
             version = data['version']


### PR DESCRIPTION
Found and fixed another bug in the Mainari module: due to API changes the previous JSON values indicating an offline server are not always reliable. Added another way of detection to conform with the new API version and make sure that the online status is always reliable.

Also changed the server MOTD (Message of the Day) from raw to clean to prevent colour formatting etc. from screwing up the plaintext.