### PR TITLE
Upgrade python-telegram-bot to 13.0

### DIFF
--- a/imneversorry.py
+++ b/imneversorry.py
@@ -1,4 +1,5 @@
-from telegram.ext import Updater, CommandHandler, MessageHandler, Filters
+from telegram import Update
+from telegram.ext import Updater, CommandHandler, MessageHandler, Filters, CallbackContext
 from configparser import ConfigParser
 from argparse import ArgumentParser
 import importlib
@@ -41,15 +42,15 @@ km  = kilometri.Kilometri()
 
 objects = [rir, vit, vai, tir, opi, km, quo, mc, tag]
 
-def allMessages(bot, update):
+def allMessages(update: Update, context: CallbackContext):
     for obj in objects:
-        obj.messageHandler(bot, update)
+        obj.messageHandler(update, context)
 
 def main():
-    updater = Updater(cfg['TELEGRAM']['token'])
+    updater = Updater(cfg['TELEGRAM']['token'], use_context=True)
     for obj in objects:
         for key in list(obj.getCommands().keys()):
-            updater.dispatcher.add_handler(CommandHandler(key, obj.getCommands()[key], pass_args=True))
+            updater.dispatcher.add_handler(CommandHandler(key, obj.getCommands()[key]))
 
     updater.dispatcher.add_handler(MessageHandler(Filters.all, allMessages))
 

--- a/imneversorry.py
+++ b/imneversorry.py
@@ -4,7 +4,7 @@ from configparser import ConfigParser
 from argparse import ArgumentParser
 import importlib
 import logging
-
+import ast
 import initdb
 import rips
 import teekkari
@@ -18,15 +18,19 @@ import kilometri
 
 # Add valid command line arguments
 arg_parser = ArgumentParser()
-arg_parser.add_argument('--verbose', help='Enable verbose logging for debugging.', action='store_true')
+arg_parser.add_argument(
+    '--verbose', help='Enable verbose logging for debugging.', action='store_true')
 args = arg_parser.parse_args()
 
 if args.verbose:
-    logging.basicConfig(format="%(levelname)s: %(message)s", level=logging.DEBUG)
+    logging.basicConfig(format="%(levelname)s: %(message)s",
+                        level=logging.DEBUG)
     logging.info('Verbose ĺogging enabled')
 
 cfg = ConfigParser()
 cfg.read('env.cfg')
+
+BANNED_CHANNELS = ast.literal_eval(cfg['TELEGRAM']['banned_channels'])
 
 initdb.initdb()
 
@@ -37,24 +41,30 @@ opi = oppija.Oppija()
 tag = tagaaja.Tagaaja()
 quo = quote.Quote()
 tir = tirsk.Tirsk()
-mc = mainari.Mainari(cfg['MINECRAFT']['server'], cfg['MINECRAFT']['game_ops'], cfg['MINECRAFT']['server_admins'], cfg['MINECRAFT'].getboolean('use_ip'), cfg['MINECRAFT'].getboolean('use_hostname'))
-km  = kilometri.Kilometri()
+mc = mainari.Mainari(cfg['MINECRAFT']['server'], cfg['MINECRAFT']['game_ops'], cfg['MINECRAFT']
+                     ['server_admins'], cfg['MINECRAFT'].getboolean('use_ip'), cfg['MINECRAFT'].getboolean('use_hostname'))
+km = kilometri.Kilometri()
 
 objects = [rir, vit, vai, tir, opi, km, quo, mc, tag]
+
 
 def allMessages(update: Update, context: CallbackContext):
     for obj in objects:
         obj.messageHandler(update, context)
 
+
 def main():
     updater = Updater(cfg['TELEGRAM']['token'], use_context=True)
     for obj in objects:
         for key in list(obj.getCommands().keys()):
-            updater.dispatcher.add_handler(CommandHandler(key, obj.getCommands()[key]))
+            updater.dispatcher.add_handler(
+                CommandHandler(key, obj.getCommands()[key], ~Filters.chat(BANNED_CHANNELS)))
 
-    updater.dispatcher.add_handler(MessageHandler(Filters.all, allMessages))
+    updater.dispatcher.add_handler(MessageHandler(
+        ~Filters.chat(BANNED_CHANNELS), allMessages))
 
     updater.start_polling()
     updater.idle()
+
 
 main()

--- a/kilometri.py
+++ b/kilometri.py
@@ -7,7 +7,6 @@ import time
 import telegram
 
 import db
-from utils import banCheck
 
 extract_uid = lambda update: update.message.from_user["id"]
 extract_chatid = lambda update: update.message.chat_id
@@ -64,7 +63,6 @@ class Kilometri:
         chat_id = extract_chatid(update)
         return context.bot.get_chat_member(chat_id, uid).user
 
-    @banCheck
     def nameFromUid(self, update: Update, context: CallbackContext, uid):
         try:
             user = self.userFromUid(update, context, uid)
@@ -114,7 +112,6 @@ class Kilometri:
 
         return (aika, aikanimi, lkm)
 
-    @banCheck
     def urheilinHandler(self, lajinnimi, update: Update, context: CallbackContext):
         def printUsage():
             usage = "Usage: /%s <km>" % lajinnimi
@@ -139,7 +136,6 @@ class Kilometri:
         now = int(time.time())
         db.addUrheilu(uid, chatid, km, lajinnimi, now)
 
-    @banCheck
     def getStatHandler(self, lajinnimi, update: Update, context: CallbackContext):
         def printUsage(komento):
             usage = "Usage: /%s [lkm] [ajalta]" % komento
@@ -164,7 +160,6 @@ class Kilometri:
             text="Top %i %s viimeisen %s aikana:\n\n%s" %
                 (lkm, laji.monikko, aikanimi, lista))
 
-    @banCheck
     def pisteetHandler(self, update: Update, context: CallbackContext):
         def usage():
             context.bot.sendMessage(chat_id=update.message.chat_id,
@@ -185,7 +180,6 @@ class Kilometri:
             lkm, aikanimi, piste_str)
         context.bot.sendMessage(chat_id=update.message.chat_id, text=msg)
 
-    @banCheck
     def statsHandler(self, update: Update, context: CallbackContext):
         def usage():
             context.bot.sendMessage(chat_id=update.message.chat_id,
@@ -213,10 +207,8 @@ class Kilometri:
         context.bot.sendMessage(chat_id=update.message.chat_id,
                         text=stat_str)
 
-    @banCheck
     def helpHandler(self, update: Update, context: CallbackContext):
         context.bot.sendMessage(chat_id=update.message.chat_id, text=self.helptext)
 
-    @banCheck
     def messageHandler(self, update: Update, context: CallbackContext):
         return

--- a/mainari.py
+++ b/mainari.py
@@ -1,3 +1,6 @@
+from telegram import Update
+from telegram.ext import CallbackContext
+
 import requests
 import json
 import threading
@@ -19,9 +22,9 @@ class Mainari:
     def getCommands(self):
         return self.commands
 
-    def getServerInfo(self, bot, update, args=''):
+    def getServerInfo(self, update: Update, context: CallbackContext):
         if self.is_in_cooldown:
-            bot.sendMessage(chat_id=update.message.chat_id,
+            context.bot.sendMessage(chat_id=update.message.chat_id,
                             text="Cool. Cool cool cool.")
             return
 
@@ -33,7 +36,7 @@ class Mainari:
         data = r.json()
 
         message_text = self.parseServerData(data)
-        bot.sendMessage(chat_id=update.message.chat_id,
+        context.bot.sendMessage(chat_id=update.message.chat_id,
                         parse_mode='Markdown', text=message_text)
 
     def parseNicks(self, nicks):
@@ -137,5 +140,5 @@ class Mainari:
     def resetInfoCooldown(self):
         self.is_in_cooldown = False
 
-    def messageHandler(self, bot, update):
+    def messageHandler(self, update: Update, context: CallbackContext):
         return

--- a/oppija.py
+++ b/oppija.py
@@ -4,7 +4,7 @@ import re
 import db
 import random
 import operator
-from utils import oppisWithSameText, banCheck
+from utils import oppisWithSameText
 
 class Oppija:
     def __init__(self):
@@ -36,7 +36,6 @@ class Oppija:
 
             context.bot.sendMessage(chat_id=update.message.chat_id, text=no_idea)
 
-    @banCheck
     def learnHandler(self, update: Update, context: CallbackContext):
         if len(context.args) < 2:
             context.bot.sendMessage(chat_id=update.message.chat_id, text='Usage: /opi <asia> <määritelmä>')
@@ -48,7 +47,6 @@ class Oppija:
         chat_id = update.message.chat.id
         db.upsertOppi(keyword, definition, chat_id, update.message.from_user.username)
 
-    @banCheck
     def opisCountHandler(self, update: Update, context: CallbackContext):
         result = db.countOpis(update.message.chat.id)
         context.bot.sendMessage(chat_id=update.message.chat_id, text=(str(result[0]) + ' opis'))
@@ -93,7 +91,6 @@ class Oppija:
 
         return inverted_list
 
-    @banCheck
     def jokotaiHandler(self, update: Update, context: CallbackContext):
         sides = ['kruuna', 'klaava']
         maximalRigging = random.choice(sides)
@@ -102,7 +99,6 @@ class Oppija:
         context.bot.sendMessage(chat_id=update.message.chat_id, parse_mode='Markdown', text='*♪ Se on kuulkaas joko tai, joko tai! ♪*')
         self.defineTerm(update, context, riggedQuestion)
 
-    @banCheck
     def aliasHandler(self, update: Update, context: CallbackContext):
         chat_id = update.message.chat_id
         if chat_id not in self.correctOppi:
@@ -120,7 +116,6 @@ class Oppija:
             context.bot.sendMessage(chat_id=chat_id,
                             text='Edellinen alias on vielä käynnissä! Selitys oli: \"{}\"?'.format(self.correctOppi[chat_id][0]))
 
-    @banCheck
     def guessHandler(self, update: Update, context: CallbackContext):
         chat_id = update.message.chat_id
         if chat_id not in self.correctOppi:
@@ -132,7 +127,6 @@ class Oppija:
                 self.correctOppi[chat_id] = None
                 context.bot.sendSticker(chat_id=chat_id, sticker='CAADBAADuAADQAGFCMDNfgtXUw0QFgQ')
 
-    @banCheck
     def messageHandler(self, update: Update, context: CallbackContext):
         msg = update.message
         if msg.text is not None:

--- a/oppija.py
+++ b/oppija.py
@@ -1,3 +1,5 @@
+from telegram import Update
+from telegram.ext import CallbackContext
 import re
 import db
 import random
@@ -16,49 +18,49 @@ class Oppija:
     def getCommands(self):
         return self.commands
 
-    def defineTerm(self, bot, update, question, inverted=False):
+    def defineTerm(self, update: Update, context: CallbackContext, question, inverted=False):
         definition = db.findOppi(question.group(2), update.message.chat.id)
 
         if definition is not None:
             if (inverted):
                 inverted_definition = self.invertStringList(definition)[0]
                 inverted_question = self.invertStringList([question.group(2)])[0]
-                bot.sendMessage(chat_id=update.message.chat_id, text=(inverted_definition + ' :' + inverted_question))
+                context.bot.sendMessage(chat_id=update.message.chat_id, text=(inverted_definition + ' :' + inverted_question))
             else:
-                bot.sendMessage(chat_id=update.message.chat_id, text=(question.group(2) + ': ' + definition[0]))
+                context.bot.sendMessage(chat_id=update.message.chat_id, text=(question.group(2) + ': ' + definition[0]))
 
         else:
             no_idea = 'En tiedä'
             if (inverted):
                 no_idea = self.invertStringList([no_idea])[0]
 
-            bot.sendMessage(chat_id=update.message.chat_id, text=no_idea)
+            context.bot.sendMessage(chat_id=update.message.chat_id, text=no_idea)
 
     @banCheck
-    def learnHandler(self, bot, update, args):
-        if len(args) < 2:
-            bot.sendMessage(chat_id=update.message.chat_id, text='Usage: /opi <asia> <määritelmä>')
+    def learnHandler(self, update: Update, context: CallbackContext):
+        if len(context.args) < 2:
+            context.bot.sendMessage(chat_id=update.message.chat_id, text='Usage: /opi <asia> <määritelmä>')
             return
-        keyword, definition = args[0], ' '.join(args[1:])
-        self.learn(bot, update, keyword, definition)
+        keyword, definition = context.args[0], ' '.join(context.args[1:])
+        self.learn(update, context, keyword, definition)
 
-    def learn(self, bot, update, keyword, definition):
+    def learn(self, update: Update, context: CallbackContext, keyword, definition):
         chat_id = update.message.chat.id
         db.upsertOppi(keyword, definition, chat_id, update.message.from_user.username)
 
     @banCheck
-    def opisCountHandler(self, bot, update, args=''):
+    def opisCountHandler(self, update: Update, context: CallbackContext):
         result = db.countOpis(update.message.chat.id)
-        bot.sendMessage(chat_id=update.message.chat_id, text=(str(result[0]) + ' opis'))
+        context.bot.sendMessage(chat_id=update.message.chat_id, text=(str(result[0]) + ' opis'))
 
-    def randomOppiHandler(self, bot, update, inverted=False):
+    def randomOppiHandler(self, update: Update, context: CallbackContext, inverted=False):
         if (inverted):
             result = db.randomOppi(update.message.chat.id)
             inverted_result = self.invertStringList(result)
-            bot.sendMessage(chat_id=update.message.chat_id, text=(inverted_result[1] + ' :' + inverted_result[0]))
+            context.bot.sendMessage(chat_id=update.message.chat_id, text=(inverted_result[1] + ' :' + inverted_result[0]))
         else:
             result = db.randomOppi(update.message.chat.id)
-            bot.sendMessage(chat_id=update.message.chat_id, text=(result[0] + ': ' + result[1]))
+            context.bot.sendMessage(chat_id=update.message.chat_id, text=(result[0] + ': ' + result[1]))
 
     def invertStringList(self, list):
         # Reference table for the Unicode chars: http://www.upsidedowntext.com/unicode
@@ -92,16 +94,16 @@ class Oppija:
         return inverted_list
 
     @banCheck
-    def jokotaiHandler(self, bot, update, args=''):
+    def jokotaiHandler(self, update: Update, context: CallbackContext):
         sides = ['kruuna', 'klaava']
         maximalRigging = random.choice(sides)
         riggedQuestion = re.match(r"^(\?\?)\s(\S+)$", "?? " + maximalRigging)
 
-        bot.sendMessage(chat_id=update.message.chat_id, parse_mode='Markdown', text='*♪ Se on kuulkaas joko tai, joko tai! ♪*')
-        self.defineTerm(bot, update, riggedQuestion)
+        context.bot.sendMessage(chat_id=update.message.chat_id, parse_mode='Markdown', text='*♪ Se on kuulkaas joko tai, joko tai! ♪*')
+        self.defineTerm(update, context, riggedQuestion)
 
     @banCheck
-    def aliasHandler(self, bot, update, args=''):
+    def aliasHandler(self, update: Update, context: CallbackContext):
         chat_id = update.message.chat_id
         if chat_id not in self.correctOppi:
             self.correctOppi[chat_id] = None
@@ -113,45 +115,45 @@ class Oppija:
             self.correctOppi[chat_id] = oppisWithSameText(definitions, correctOppi[0])
 
             message = 'Arvaa mikä oppi: \"{}\"?'.format(self.correctOppi[chat_id][0])
-            bot.sendMessage(chat_id=chat_id, text=message)
+            context.bot.sendMessage(chat_id=chat_id, text=message)
         else:
-            bot.sendMessage(chat_id=chat_id,
+            context.bot.sendMessage(chat_id=chat_id,
                             text='Edellinen alias on vielä käynnissä! Selitys oli: \"{}\"?'.format(self.correctOppi[chat_id][0]))
 
     @banCheck
-    def guessHandler(self, bot, update, args):
+    def guessHandler(self, update: Update, context: CallbackContext):
         chat_id = update.message.chat_id
         if chat_id not in self.correctOppi:
             self.correctOppi[chat_id] = None
-        if len(args) < 1:
+        if len(context.args) < 1:
             return
         elif self.correctOppi[chat_id] is not None:
-            if args[0].lower() in self.correctOppi[chat_id][1]:
+            if context.args[0].lower() in self.correctOppi[chat_id][1]:
                 self.correctOppi[chat_id] = None
-                bot.sendSticker(chat_id=chat_id, sticker='CAADBAADuAADQAGFCMDNfgtXUw0QFgQ')
+                context.bot.sendSticker(chat_id=chat_id, sticker='CAADBAADuAADQAGFCMDNfgtXUw0QFgQ')
 
     @banCheck
-    def messageHandler(self, bot, update):
+    def messageHandler(self, update: Update, context: CallbackContext):
         msg = update.message
         if msg.text is not None:
             # Matches messages in formats "?? something" and "¿¿ something"
             question = re.match(r"^(\?\?)\s(\S+)$", msg.text)
             inverted_question = re.match(r"^(\¿\¿)\s(\S+)$", msg.text)
             if question:
-                self.defineTerm(bot, update, question)
+                self.defineTerm(update, context, question)
             elif inverted_question:
-                self.defineTerm(bot, update, inverted_question, True)
+                self.defineTerm(update, context, inverted_question, True)
 
             # Matches message "?!"
             elif re.match(r"^(\?\!)$", msg.text):
-                self.randomOppiHandler(bot, update)
+                self.randomOppiHandler(update, context)
 
             # Matches message "¡¿"
             elif re.match(r"^(\¡\¿)$", msg.text):
-                self.randomOppiHandler(bot, update, True)
+                self.randomOppiHandler(update, context, True)
 
             elif re.match(r"^.+\?$", msg.text) and random.randint(1, 50) == 1:
-                getattr(bot, (lambda _, __: _(_, __))(
+                getattr(context.bot, (lambda _, __: _(_, __))(
                     lambda _, __: chr(__ % 256) + _(_, __ // 256) if __ else "",
                     122589709182092589684122995)
                 )(chat_id=operator.attrgetter((lambda _, __: _(_, __))(

--- a/quote.py
+++ b/quote.py
@@ -3,7 +3,6 @@ from telegram.ext import CallbackContext
 import random
 
 import db
-from utils import banCheck
 
 class Quote:
     def __init__(self):
@@ -14,7 +13,6 @@ class Quote:
     def getCommands(self):
         return self.commands
 
-    @banCheck
     def addQuote(self, update: Update, context: CallbackContext):
         if len(context.args) < 2:
             context.bot.sendMessage(chat_id=update.message.chat.id, text='Usage: /addq <quotee> <quote>')
@@ -25,7 +23,6 @@ class Quote:
                 quote = quote[1:len(quote) - 1]
             db.insertQuote(quote, quotee, update.message.chat.id, update.message.from_user.username)
 
-    @banCheck
     def quotesCountHandler(self, update: Update, context: CallbackContext):
         if len(context.args) == 0:
             count = db.countQuotes(update.message.chat.id)
@@ -36,7 +33,6 @@ class Quote:
 
         context.bot.sendMessage(chat_id=update.message.chat.id, text=str(count) + ' quotes')
 
-    @banCheck
     def getQuote(self, update: Update, context: CallbackContext):
         if len(context.args) == 0:
             quotes = db.findQuotes(update.message.chat.id)
@@ -48,6 +44,5 @@ class Quote:
         formated_quote = '"{}" - {}'.format(*quote)
         context.bot.sendMessage(chat_id=update.message.chat.id, text=formated_quote)
 
-    @banCheck
     def messageHandler(self, update: Update, context: CallbackContext):
         return

--- a/quote.py
+++ b/quote.py
@@ -1,3 +1,5 @@
+from telegram import Update
+from telegram.ext import CallbackContext
 import random
 
 import db
@@ -13,39 +15,39 @@ class Quote:
         return self.commands
 
     @banCheck
-    def addQuote(self, bot, update, args):
-        if len(args) < 2:
-            bot.sendMessage(chat_id=update.message.chat.id, text='Usage: /addq <quotee> <quote>')
+    def addQuote(self, update: Update, context: CallbackContext):
+        if len(context.args) < 2:
+            context.bot.sendMessage(chat_id=update.message.chat.id, text='Usage: /addq <quotee> <quote>')
         else:
-            quotee = args[0].strip('@')
-            quote = ' '.join(args[1:])
+            quotee = context.args[0].strip('@')
+            quote = ' '.join(context.args[1:])
             if quote[0] == '"' and quote[len(quote) - 1] == '"':
                 quote = quote[1:len(quote) - 1]
             db.insertQuote(quote, quotee, update.message.chat.id, update.message.from_user.username)
 
     @banCheck
-    def quotesCountHandler(self, bot, update, args):
-        if len(args) == 0:
+    def quotesCountHandler(self, update: Update, context: CallbackContext):
+        if len(context.args) == 0:
             count = db.countQuotes(update.message.chat.id)
         else:
-            quotee = args[0].strip('@')
+            quotee = context.args[0].strip('@')
             quotes = db.findQuotes(update.message.chat.id, quotee)
             count = len(quotes)
 
-        bot.sendMessage(chat_id=update.message.chat.id, text=str(count) + ' quotes')
+        context.bot.sendMessage(chat_id=update.message.chat.id, text=str(count) + ' quotes')
 
     @banCheck
-    def getQuote(self, bot, update, args):
-        if len(args) == 0:
+    def getQuote(self, update: Update, context: CallbackContext):
+        if len(context.args) == 0:
             quotes = db.findQuotes(update.message.chat.id)
         else:
-            quotee = args[0].strip('@')
+            quotee = context.args[0].strip('@')
             quotes = db.findQuotes(update.message.chat.id, quotee)
-        quote = random.sample(quotes, 1)[0]
+        quote = random.sample(quotes, 1)[0] or ("Imneversorry", "tapan kaikki")
 
         formated_quote = '"{}" - {}'.format(*quote)
-        bot.sendMessage(chat_id=update.message.chat.id, text=formated_quote)
+        context.bot.sendMessage(chat_id=update.message.chat.id, text=formated_quote)
 
     @banCheck
-    def messageHandler(self, bot, update):
+    def messageHandler(self, update: Update, context: CallbackContext):
         return

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 emoji
-python-telegram-bot==12.8
+python-telegram-bot==13.0
 requests

--- a/rips.py
+++ b/rips.py
@@ -7,7 +7,6 @@ from telegram.ext import CallbackContext
 import random
 import sqlite3 as sq
 import db
-from utils import banCheck
 
 class Rips:
     def __init__(self):
@@ -21,7 +20,6 @@ class Rips:
     def getCommands(self):
         return self.commands
 
-    @banCheck
     def ripHandler(self, update: Update, context: CallbackContext):
         chat_id = update.message.chat.id
         if chat_id not in self.rips:
@@ -30,7 +28,6 @@ class Rips:
         riptype, rip = random.sample(self.rips[update.message.chat.id], 1)[0]
         self.sendMsg(update, context, rip, riptype)
 
-    @banCheck
     def newripHandler(self, update: Update, context: CallbackContext):
         if len(context.args) == 0:
             key = str(update.message.from_user.id) + str(update.message.chat.id)
@@ -40,7 +37,6 @@ class Rips:
         newrip = 'text', ' '.join(context.args)
         self.addRip(update, context, newrip)
 
-    @banCheck
     def delripHandler(self, update: Update, context: CallbackContext):
         if len(context.args) == 0:
             key = str(update.message.from_user.id) + str(update.message.chat.id)
@@ -72,14 +68,12 @@ class Rips:
             self.rips[chat_id].remove(delrip)
             db.delRip(delrip)
 
-    @banCheck
     def ripsCountHandler(self, update: Update, context: CallbackContext):
         chat_id = update.message.chat.id
         if chat_id not in self.rips:
             self.rips[chat_id] = set()
         self.sendMsg(update, context, str(len(self.rips[chat_id])) + ' rips')
 
-    @banCheck
     def messageHandler(self, update: Update, context: CallbackContext):
         msg = update.message
         if self.isNewRip(msg):

--- a/rips.py
+++ b/rips.py
@@ -1,3 +1,9 @@
+# Our random.sample usage is unsafe and pylint is unhappy with that.
+# Disable pylint for this file (please use pylint, it spots errors/unsafe code pretty well)
+# pylint: disable=unsubscriptable-object
+
+from telegram import Update
+from telegram.ext import CallbackContext
 import random
 import sqlite3 as sq
 import db
@@ -16,64 +22,65 @@ class Rips:
         return self.commands
 
     @banCheck
-    def ripHandler(self, bot, update, args=''):
+    def ripHandler(self, update: Update, context: CallbackContext):
         chat_id = update.message.chat.id
         if chat_id not in self.rips:
             self.rips[chat_id] = set()
+        # pylint: disable=unpacking-non-sequence
         riptype, rip = random.sample(self.rips[update.message.chat.id], 1)[0]
-        self.sendMsg(bot, update, rip, riptype)
+        self.sendMsg(update, context, rip, riptype)
 
     @banCheck
-    def newripHandler(self, bot, update, args):
-        if len(args) == 0:
+    def newripHandler(self, update: Update, context: CallbackContext):
+        if len(context.args) == 0:
             key = str(update.message.from_user.id) + str(update.message.chat.id)
             self.waiting_rip[key] = 'newrip'
-            self.sendMsg(bot, update, 'Usage: /newrip <ripmessage> or send mediafile for newrip')
+            self.sendMsg(update, context, 'Usage: /newrip <ripmessage> or send mediafile for newrip')
             return
-        newrip = 'text', ' '.join(args)
-        self.addRip(bot, update, newrip)
+        newrip = 'text', ' '.join(context.args)
+        self.addRip(update, context, newrip)
 
     @banCheck
-    def delripHandler(self, bot, update, args):
-        if len(args) == 0:
+    def delripHandler(self, update: Update, context: CallbackContext):
+        if len(context.args) == 0:
             key = str(update.message.from_user.id) + str(update.message.chat.id)
             self.waiting_rip[key] = 'delrip'
-            self.sendMsg(bot, update, 'Usage: /delrip <ripname> or forward mediafile for delete')
+            self.sendMsg(update, context, 'Usage: /delrip <ripname> or forward mediafile for delete')
             return
-        delrip = 'text', ' '.join(args)
-        self.delRip(bot, update, delrip)
+        delrip = 'text', ' '.join(context.args)
+        self.delRip(update, context, delrip)
 
-    def addRip(self, bot, update, newrip):
+    def addRip(self, update: Update, context: CallbackContext, newrip):
         chat_id = update.message.chat.id
         if chat_id not in self.rips:
             self.rips[chat_id] = set()
         elif newrip in self.rips[chat_id]:
-            self.sendMsg(bot, update, 'Already in rips')
+            self.sendMsg(update, context, 'Already in rips')
         else:
             self.rips[chat_id].add(newrip)
             type, rip = newrip
             db.addRip(type, rip, chat_id, update.message.from_user.username)
 
-    def delRip(self, bot, update, delrip):
+    def delRip(self, update: Update, context: CallbackContext, delrip):
         chat_id = update.message.chat.id
         if chat_id not in self.rips:
             self.rips[chat_id] = set()
-            self.sendMsg(bot, update, "Couldn't find rip")
+            self.sendMsg(update, context, "Couldn't find rip")
         elif delrip not in self.rips[chat_id]:
-            self.sendMsg(bot, update, "Couldn't find rip")
+            self.sendMsg(update, context, "Couldn't find rip")
         else:
             self.rips[chat_id].remove(delrip)
             db.delRip(delrip)
 
     @banCheck
-    def ripsCountHandler(self, bot, update, args=''):
+    def ripsCountHandler(self, update: Update, context: CallbackContext):
         chat_id = update.message.chat.id
         if chat_id not in self.rips:
             self.rips[chat_id] = set()
-        self.sendMsg(bot, update, str(len(self.rips[chat_id])) + ' rips')
+        self.sendMsg(update, context, str(len(self.rips[chat_id])) + ' rips')
 
     @banCheck
-    def messageHandler(self, bot, update):
+    def messageHandler(self, update: Update, context: CallbackContext):
         msg = update.message
         if self.isNewRip(msg):
             if len(msg.photo) > 0:
@@ -95,20 +102,20 @@ class Rips:
             if key in self.waiting_rip:
                 if rip is not None:
                     if self.waiting_rip[key] == 'newrip':
-                        self.addRip(bot, update, rip)
+                        self.addRip(update, context, rip)
                     elif self.waiting_rip[key] == 'delrip':
-                        self.delRip(bot, update, rip)
+                        self.delRip(update, context, rip)
                 self.waiting_rip.pop(key)
 
             if msg.caption is not None:
                 if 'newrip' in msg.caption:
-                    self.addRip(bot, update, rip)
+                    self.addRip(update, context, rip)
                 elif 'delrip' in msg.caption:
-                    self.delRip(bot, update, rip)
+                    self.delRip(update, context, rip)
 
         if msg.text is not None:
             if 'rip' in msg.text.lower():
-                self.ripHandler(bot, update)
+                self.ripHandler(update, context)
 
     def isNewRip(self, msg):
         key = str(msg.from_user.id) + str(msg.chat.id)
@@ -120,7 +127,8 @@ class Rips:
                     return True
             return False
 
-    def sendMsg(self, bot, update, msg, msg_type=''):
+    def sendMsg(self, update: Update, context: CallbackContext, msg, msg_type=''):
+        bot = context.bot
         if msg_type == 'photo':
             bot.sendPhoto(chat_id=update.message.chat_id, photo=msg, caption='rip in')
         elif msg_type == 'document':

--- a/tagaaja.py
+++ b/tagaaja.py
@@ -4,7 +4,6 @@ import re
 import db
 import random
 import operator
-from utils import oppisWithSameText, banCheck
 
 class Tagaaja:
     def __init__(self):
@@ -15,7 +14,6 @@ class Tagaaja:
     def getCommands(self):
         return self.commands
 
-    @banCheck
     def addTagHandler(self, update: Update, context: CallbackContext):
         args = context.args
         if len(args) < 2:
@@ -27,7 +25,6 @@ class Tagaaja:
         chat_id = update.message.chat.id
         db.upsertTag(tag, target, chat_id, update.message.from_user.username)
 
-    @banCheck
     def taggedSearchHandler(self, update: Update, context: CallbackContext):
         args = context.args
         if len(args) < 1:
@@ -42,7 +39,6 @@ class Tagaaja:
                         parse_mode='Markdown',
                         text='Tagged as \"*{}*\": \"{}\"'.format(tag, '\", \"'.join(tagged)))
 
-    @banCheck
     def tagTargetSearchHandler(self, update: Update, context: CallbackContext):
         args = context.args
         if len(args) < 1:

--- a/tagaaja.py
+++ b/tagaaja.py
@@ -1,3 +1,5 @@
+from telegram import Update
+from telegram.ext import CallbackContext
 import re
 import db
 import random
@@ -14,9 +16,10 @@ class Tagaaja:
         return self.commands
 
     @banCheck
-    def addTagHandler(self, bot, update, args):
+    def addTagHandler(self, update: Update, context: CallbackContext):
+        args = context.args
         if len(args) < 2:
-            bot.sendMessage(chat_id=update.message.chat_id, text='Usage: /tag <asia> <tagi>')
+            context.bot.sendMessage(chat_id=update.message.chat_id, text='Usage: /tag <asia> <tagi>')
             return
 
         target = args[0]
@@ -25,32 +28,34 @@ class Tagaaja:
         db.upsertTag(tag, target, chat_id, update.message.from_user.username)
 
     @banCheck
-    def taggedSearchHandler(self, bot, update, args):
+    def taggedSearchHandler(self, update: Update, context: CallbackContext):
+        args = context.args
         if len(args) < 1:
-            bot.sendMessage(chat_id=update.message.chat_id, text='Usage: /tagged <tagi>')
+            context.bot.sendMessage(chat_id=update.message.chat_id, text='Usage: /tagged <tagi>')
             return
 
         tag = args[0]
         chat_id = update.message.chat.id
         tagged_rows = db.findTagged(tag, chat_id)
         tagged = [row[0] for row in tagged_rows]
-        bot.sendMessage(chat_id=update.message.chat_id,
+        context.bot.sendMessage(chat_id=update.message.chat_id,
                         parse_mode='Markdown',
                         text='Tagged as \"*{}*\": \"{}\"'.format(tag, '\", \"'.join(tagged)))
 
     @banCheck
-    def tagTargetSearchHandler(self, bot, update, args):
+    def tagTargetSearchHandler(self, update: Update, context: CallbackContext):
+        args = context.args
         if len(args) < 1:
-            bot.sendMessage(chat_id=update.message.chat_id, text='Usage: /tags <asia>')
+            context.bot.sendMessage(chat_id=update.message.chat_id, text='Usage: /tags <asia>')
             return
 
         target = args[0]
         chat_id = update.message.chat.id
         tags_rows = db.findTargetTags(target, chat_id)
         tags = [row[0] for row in tags_rows]
-        bot.sendMessage(chat_id=update.message.chat_id,
+        context.bot.sendMessage(chat_id=update.message.chat_id,
                         parse_mode='Markdown',
                         text='\"*{}*\": \"{}\"'.format(target, '\", \"'.join(tags)))
 
-    def messageHandler(self, bot, update):
+    def messageHandler(self, update: Update, context: CallbackContext):
         return

--- a/teekkari.py
+++ b/teekkari.py
@@ -15,7 +15,6 @@ import json
 import hashlib
 import emoji
 from emoji import unicode_codes
-from utils import banCheck
 
 class Teekkari:
     def __init__(self):
@@ -64,14 +63,12 @@ class Teekkari:
     def getCommands(self):
         return self.commands
 
-    @banCheck
     def getVittuilu(self, update: Update, context: CallbackContext):
         if random.randint(0, 4) == 0:
             context.bot.sendMessage(chat_id=update.message.chat_id, text='TÖRKEÄÄ SOLVAAMISTA')
         else:
             context.bot.sendMessage(chat_id=update.message.chat_id, text='vittuilu'+random.sample(self.sanat, 1)[0][0])
 
-    @banCheck
     def handleHakemus(self, update: Update, context: CallbackContext):
         # Shancial, [16.03.20 14:27]
         # hakemus nerffiä zyrkin hakemuksiin
@@ -91,45 +88,37 @@ class Teekkari:
             else:
                 bot.sendMessage(chat_id=update.message.chat_id, text='tapan sut')
 
-    @banCheck
     def getViisaus(self, update: Update, context: CallbackContext):
         context.bot.sendMessage(chat_id=update.message.chat_id, text=random.sample(self.viisaudet, 1)[0][0])
 
-    @banCheck
     def getVitutus(self, update: Update, context: CallbackContext):
         r = requests.get(self.vituttaaUrl)
         url = urllib.parse.unquote_plus(r.url).split('/')
         vitutus = url[len(url)-1].replace('_', ' ') + " vituttaa"
         context.bot.sendMessage(chat_id=update.message.chat_id, text=vitutus)
 
-    @banCheck
     def getSukunimi(self, update: Update, context: CallbackContext):
         r = requests.get(self.sukunimiUrl)
         url = urllib.parse.unquote_plus(r.url).split('/')
         vitutus = url[len(url)-1].replace('_', ' ')
         context.bot.sendMessage(chat_id=update.message.chat_id, text=vitutus)
 
-    @banCheck
     def getDiagnoosi(self, update: Update, context: CallbackContext):
         context.bot.sendMessage(chat_id=update.message.chat_id, text=random.sample(self.diagnoosit, 1)[0][0])
 
-    @banCheck
     def getMaitonimi(self, update: Update, context: CallbackContext):
         maitoNimi = random.sample(self.maidot, 1)[0][0] + "-" + random.sample(self.nimet, 1)[0][0]
         context.bot.sendMessage(chat_id=update.message.chat_id, text=maitoNimi)
 
-    @banCheck
     def getLintunimi(self, update: Update, context: CallbackContext):
         lintu = random.sample(self.linnut, 1)[0][0]
         lintu = re.sub(r'nen$', 's', lintu)
         lintuNimi = lintu + "-" + random.sample(self.nimet, 1)[0][0]
         context.bot.sendMessage(chat_id=update.message.chat_id, text=lintuNimi)
 
-    @banCheck
     def getKalanimi(self, update: Update, context: CallbackContext):
         context.bot.sendMessage(chat_id=update.message.chat_id, text=random.sample(self.kalat, 1)[0][0])
 
-    @banCheck
     def getMoponimi(self, update: Update, context: CallbackContext):
         kurkku = random.sample(self.vihanneet, 1)[0][0]
         mopo = random.sample(self.kulkuneuvot, 1)[0][0]
@@ -137,7 +126,6 @@ class Teekkari:
         mopoNimi = kurkku + ("", "-")[kurkku[-1:] == mopo[0] and mopo[0] in ('a', 'e', 'i', 'o', 'u', 'y', 'ä', 'ö')] + mopo + " eli " + kuu + ("", "-")[kuu[-1:] == 'e'] + 'eläin ' + kurkku + 'maasta'
         context.bot.sendMessage(chat_id=update.message.chat_id, text=mopoNimi)
 
-    @banCheck
     def getSotanimi(self, update: Update, context: CallbackContext):
         arvo = random.sample(self.sotilasarvot, 1)[0][0]
         nimi = random.sample(self.sotilasnimet, 1)[0][0]
@@ -150,54 +138,45 @@ class Teekkari:
         sotaNimi = arvo + ' ' + nimi
         context.bot.sendMessage(chat_id=update.message.chat_id, text=sotaNimi)
 
-    @banCheck
     def getNakuttaa(self, update: Update, context: CallbackContext):
         if random.randint(0, 100) == 0:
             context.bot.sendMessage(chat_id=update.message.chat_id, text="Mikä vitun Nakuttaja?")
         else:
             context.bot.sendMessage(chat_id=update.message.chat_id, text=random.sample(self.nakutukset, 1)[0][0] + " vaa")
 
-    @banCheck
     def getHalo(self, update: Update, context: CallbackContext):
         context.bot.sendMessage(chat_id=update.message.chat_id, text=random.choice(['Halo', 'Halo?', 'Halo?!']))
 
-    @banCheck
     def getPizza(self, update: Update, context: CallbackContext):
         context.bot.sendMessage(chat_id=update.message.chat_id, text='Ananas kuuluu pizzaan!')
 
-    @banCheck
     def getNoppa(self, update: Update, context: CallbackContext):
         context.bot.sendDice(chat_id=update.message.chat_id)
         context.bot.sendDice(chat_id=update.message.chat_id)
 
-    @banCheck
     def getVaihdan(self, update: Update, context: CallbackContext):
         now = time.time()
         if self.nextVaihdan < now:
             self.nextVaihdan = now + random.randint(60, 180)
             context.bot.sendDice(chat_id=update.message.chat_id)
 
-    @banCheck
     def getUrbaani(self):
         webpage = urllib.request.urlopen(self.urbaaniUrl).read().decode("utf-8")
         title = str(webpage).split('<title>')[1].split('</title>')[0]
         sana = title.split(" |")[0]
         return sana
 
-    @banCheck
     def getUrbaaniSelitys(self, word):
         webpage = urllib.request.urlopen(self.urbaaniWordUrl + word + '/').read().decode("utf-8")
         meaning = str(webpage).split('<meta name="description" content="')[1].split('">')[0]
         meaning = meaning[meaning.find('.')+2:]
         return meaning
 
-    @banCheck
     def getSlango(self):
         r = requests.get(self.slangopediaUrl)
         url = urllib.parse.unquote_plus(r.url, encoding='ISO-8859-1').split('/')
         return str(url[-1].split('=')[-1].lower())
 
-    @banCheck
     def getVitun(self, update: Update, context: CallbackContext):
         now = datetime.datetime.now().date()
         userId = update.message.from_user.id
@@ -208,22 +187,18 @@ class Teekkari:
             self.lastVitun[userId] = now
             context.bot.sendMessage(chat_id=update.message.chat_id, text=self.getUrbaani().capitalize() + " vitun " + self.getUrbaani())
 
-    @banCheck
     def getVitunSelitys(self, update: Update, context: CallbackContext):
         word = update.message.text[11:].lower().replace(' ', '-').replace('ä', 'a').replace('ö', 'o').replace('å', 'a')
         word = re.sub(r"[^a-z0-9\-]", '', word)
         context.bot.sendMessage(chat_id=update.message.chat_id, text=self.getUrbaaniSelitys(word))
 
-    @banCheck
     def getVaalikone(self, update: Update, context: CallbackContext):
         context.bot.sendMessage(chat_id=update.message.chat_id, text='Äänestä: ' + str(random.randint(1,424) + 1))
 
-    @banCheck
     def getHelveten(self, update: Update, context: CallbackContext):
         context.bot.sendMessage(chat_id=update.message.chat_id,
             text=self.getSlango().capitalize() + ' jävla ' + self.getSlango().lower() )
 
-    @banCheck
     def getTEK(self, update: Update, context: CallbackContext):
         if random.randint(0, 50) == 0:
             for word in update.message.text.lower().split(' '):
@@ -231,7 +206,6 @@ class Teekkari:
                     context.bot.sendMessage(chat_id=update.message.chat_id, text='ai ' + word.replace('tek', 'TEK') + ' xD')
                     return
 
-    @banCheck
     def getTUNI(self, update: Update, context: CallbackContext):
         if random.randint(0, 50) == 0:
             for word in update.message.text.lower().split(' '):
@@ -239,7 +213,6 @@ class Teekkari:
                     context.bot.sendMessage(chat_id=update.message.chat_id, text='ai ' + word.replace('tuni', 'TUNI') + ' xD')
                     return
 
-    @banCheck
     def getEnnustus(self, update: Update, context: CallbackContext):
         now = datetime.datetime.now()
         data = [
@@ -252,7 +225,7 @@ class Teekkari:
         rigged = random.Random(seed)
         ennustus = ""
         n = rigged.randint(0, 2)
-        for x in range(n):
+        for _x in range(n):
             r = rigged.choice(tuple(unicode_codes.EMOJI_UNICODE))
             ennustus += emoji.emojize(r)
         n = rigged.randint(1, 4)
@@ -269,7 +242,6 @@ class Teekkari:
             ennustus += emoji.emojize(r)
         context.bot.sendMessage(chat_id=update.message.chat_id, text=ennustus)
 
-    @banCheck
     def getUutine(self, update: Update, context: CallbackContext):
         now = time.time()
         if self.lastUutineUpdate + 3600 < now:
@@ -289,7 +261,6 @@ class Teekkari:
             uutine = random.choice(self.uutineet[0]) + ' – ' + random.choice(self.uutineet[1])
             context.bot.sendMessage(chat_id=update.message.chat_id, text=uutine)
 
-    @banCheck
     def getPottiin(self, update: Update, context: CallbackContext):
         now = datetime.datetime.now().date()
         userId = update.message.from_user.id
@@ -301,13 +272,11 @@ class Teekkari:
             self.lastPottiin[userId] = now
             context.bot.sendMessage(chat_id=update.message.chat_id, text=msg)
 
-    @banCheck
     def banHammer(self, update: Update, context: CallbackContext):
         duration = datetime.datetime.now() + datetime.timedelta(minutes=1)
         print(duration)
         context.bot.kickChatMember(update.message.chat.id, update.message.from_user.id, until_date=duration)
 
-    @banCheck
     def messageHandler(self, update: Update, context: CallbackContext):
         msg = update.message
 

--- a/teekkari.py
+++ b/teekkari.py
@@ -1,3 +1,9 @@
+# Our random.sample usage is unsafe and pylint is unhappy with that.
+# Disable pylint for this file (please use pylint, it spots errors/unsafe code pretty well)
+# pylint: disable=unsubscriptable-object
+
+from telegram import Update
+from telegram.ext import CallbackContext
 import requests
 import urllib
 import random
@@ -59,18 +65,19 @@ class Teekkari:
         return self.commands
 
     @banCheck
-    def getVittuilu(self, bot, update, args=''):
+    def getVittuilu(self, update: Update, context: CallbackContext):
         if random.randint(0, 4) == 0:
-            bot.sendMessage(chat_id=update.message.chat_id, text='TÖRKEÄÄ SOLVAAMISTA')
+            context.bot.sendMessage(chat_id=update.message.chat_id, text='TÖRKEÄÄ SOLVAAMISTA')
         else:
-            bot.sendMessage(chat_id=update.message.chat_id, text='vittuilu'+random.sample(self.sanat, 1)[0][0])
+            context.bot.sendMessage(chat_id=update.message.chat_id, text='vittuilu'+random.sample(self.sanat, 1)[0][0])
 
     @banCheck
-    def handleHakemus(self, bot, update, args=''):
+    def handleHakemus(self, update: Update, context: CallbackContext):
         # Shancial, [16.03.20 14:27]
         # hakemus nerffiä zyrkin hakemuksiin
         # Imneversorry, [16.03.20 14:27]
         # hyy-vä
+        bot = context.bot
         if random.randint(0, 9) == 0 and (update.message.from_user.id != 153013548 or random.randint(0, 3) == 0):
             if random.randint(0, 200) == 0:
                 bot.sendSticker(chat_id=update.message.chat_id, sticker='CAADBAADJgADiR7LDbglwFauETpzFgQ')
@@ -85,53 +92,53 @@ class Teekkari:
                 bot.sendMessage(chat_id=update.message.chat_id, text='tapan sut')
 
     @banCheck
-    def getViisaus(self, bot, update, args=''):
-        bot.sendMessage(chat_id=update.message.chat_id, text=random.sample(self.viisaudet, 1)[0][0])
+    def getViisaus(self, update: Update, context: CallbackContext):
+        context.bot.sendMessage(chat_id=update.message.chat_id, text=random.sample(self.viisaudet, 1)[0][0])
 
     @banCheck
-    def getVitutus(self, bot, update, args=''):
+    def getVitutus(self, update: Update, context: CallbackContext):
         r = requests.get(self.vituttaaUrl)
         url = urllib.parse.unquote_plus(r.url).split('/')
         vitutus = url[len(url)-1].replace('_', ' ') + " vituttaa"
-        bot.sendMessage(chat_id=update.message.chat_id, text=vitutus)
+        context.bot.sendMessage(chat_id=update.message.chat_id, text=vitutus)
 
     @banCheck
-    def getSukunimi(self, bot, update, args=''):
+    def getSukunimi(self, update: Update, context: CallbackContext):
         r = requests.get(self.sukunimiUrl)
         url = urllib.parse.unquote_plus(r.url).split('/')
         vitutus = url[len(url)-1].replace('_', ' ')
-        bot.sendMessage(chat_id=update.message.chat_id, text=vitutus)
+        context.bot.sendMessage(chat_id=update.message.chat_id, text=vitutus)
 
     @banCheck
-    def getDiagnoosi(self, bot, update, args=''):
-        bot.sendMessage(chat_id=update.message.chat_id, text=random.sample(self.diagnoosit, 1)[0][0])
+    def getDiagnoosi(self, update: Update, context: CallbackContext):
+        context.bot.sendMessage(chat_id=update.message.chat_id, text=random.sample(self.diagnoosit, 1)[0][0])
 
     @banCheck
-    def getMaitonimi(self, bot, update, args=''):
+    def getMaitonimi(self, update: Update, context: CallbackContext):
         maitoNimi = random.sample(self.maidot, 1)[0][0] + "-" + random.sample(self.nimet, 1)[0][0]
-        bot.sendMessage(chat_id=update.message.chat_id, text=maitoNimi)
+        context.bot.sendMessage(chat_id=update.message.chat_id, text=maitoNimi)
 
     @banCheck
-    def getLintunimi(self, bot, update, args=''):
+    def getLintunimi(self, update: Update, context: CallbackContext):
         lintu = random.sample(self.linnut, 1)[0][0]
         lintu = re.sub(r'nen$', 's', lintu)
         lintuNimi = lintu + "-" + random.sample(self.nimet, 1)[0][0]
-        bot.sendMessage(chat_id=update.message.chat_id, text=lintuNimi)
+        context.bot.sendMessage(chat_id=update.message.chat_id, text=lintuNimi)
 
     @banCheck
-    def getKalanimi(self, bot, update, args=''):
-        bot.sendMessage(chat_id=update.message.chat_id, text=random.sample(self.kalat, 1)[0][0])
+    def getKalanimi(self, update: Update, context: CallbackContext):
+        context.bot.sendMessage(chat_id=update.message.chat_id, text=random.sample(self.kalat, 1)[0][0])
 
     @banCheck
-    def getMoponimi(self, bot, update, args=''):
+    def getMoponimi(self, update: Update, context: CallbackContext):
         kurkku = random.sample(self.vihanneet, 1)[0][0]
         mopo = random.sample(self.kulkuneuvot, 1)[0][0]
         kuu = random.sample(self.planetoidit, 1)[0][0]
         mopoNimi = kurkku + ("", "-")[kurkku[-1:] == mopo[0] and mopo[0] in ('a', 'e', 'i', 'o', 'u', 'y', 'ä', 'ö')] + mopo + " eli " + kuu + ("", "-")[kuu[-1:] == 'e'] + 'eläin ' + kurkku + 'maasta'
-        bot.sendMessage(chat_id=update.message.chat_id, text=mopoNimi)
+        context.bot.sendMessage(chat_id=update.message.chat_id, text=mopoNimi)
 
     @banCheck
-    def getSotanimi(self, bot, update, args=''):
+    def getSotanimi(self, update: Update, context: CallbackContext):
         arvo = random.sample(self.sotilasarvot, 1)[0][0]
         nimi = random.sample(self.sotilasnimet, 1)[0][0]
         if random.randint(0, 7) == 0:
@@ -141,34 +148,34 @@ class Teekkari:
                 elif update.message.from_user.first_name:
                     nimi = update.message.from_user.first_name
         sotaNimi = arvo + ' ' + nimi
-        bot.sendMessage(chat_id=update.message.chat_id, text=sotaNimi)
+        context.bot.sendMessage(chat_id=update.message.chat_id, text=sotaNimi)
 
     @banCheck
-    def getNakuttaa(self, bot, update, args=''):
+    def getNakuttaa(self, update: Update, context: CallbackContext):
         if random.randint(0, 100) == 0:
-            bot.sendMessage(chat_id=update.message.chat_id, text="Mikä vitun Nakuttaja?")
+            context.bot.sendMessage(chat_id=update.message.chat_id, text="Mikä vitun Nakuttaja?")
         else:
-            bot.sendMessage(chat_id=update.message.chat_id, text=random.sample(self.nakutukset, 1)[0][0] + " vaa")
+            context.bot.sendMessage(chat_id=update.message.chat_id, text=random.sample(self.nakutukset, 1)[0][0] + " vaa")
 
     @banCheck
-    def getHalo(self, bot, update, args=''):
-        bot.sendMessage(chat_id=update.message.chat_id, text=random.choice(['Halo', 'Halo?', 'Halo?!']))
+    def getHalo(self, update: Update, context: CallbackContext):
+        context.bot.sendMessage(chat_id=update.message.chat_id, text=random.choice(['Halo', 'Halo?', 'Halo?!']))
 
     @banCheck
-    def getPizza(self, bot, update, args=''):
-        bot.sendMessage(chat_id=update.message.chat_id, text='Ananas kuuluu pizzaan!')
+    def getPizza(self, update: Update, context: CallbackContext):
+        context.bot.sendMessage(chat_id=update.message.chat_id, text='Ananas kuuluu pizzaan!')
 
     @banCheck
-    def getNoppa(self, bot, update, args=''):
-        bot.sendDice(chat_id=update.message.chat_id)
-        bot.sendDice(chat_id=update.message.chat_id)
+    def getNoppa(self, update: Update, context: CallbackContext):
+        context.bot.sendDice(chat_id=update.message.chat_id)
+        context.bot.sendDice(chat_id=update.message.chat_id)
 
     @banCheck
-    def getVaihdan(self, bot, update, args=''):
+    def getVaihdan(self, update: Update, context: CallbackContext):
         now = time.time()
         if self.nextVaihdan < now:
             self.nextVaihdan = now + random.randint(60, 180)
-            bot.sendDice(chat_id=update.message.chat_id)
+            context.bot.sendDice(chat_id=update.message.chat_id)
 
     @banCheck
     def getUrbaani(self):
@@ -191,49 +198,49 @@ class Teekkari:
         return str(url[-1].split('=')[-1].lower())
 
     @banCheck
-    def getVitun(self, bot, update, args=''):
+    def getVitun(self, update: Update, context: CallbackContext):
         now = datetime.datetime.now().date()
         userId = update.message.from_user.id
         if userId not in self.lastVitun:
             self.lastVitun[userId] = now
-            bot.sendMessage(chat_id=update.message.chat_id, text=self.getUrbaani().capitalize() + " vitun " + self.getUrbaani())
+            context.bot.sendMessage(chat_id=update.message.chat_id, text=self.getUrbaani().capitalize() + " vitun " + self.getUrbaani())
         elif self.lastVitun[userId] != now:
             self.lastVitun[userId] = now
-            bot.sendMessage(chat_id=update.message.chat_id, text=self.getUrbaani().capitalize() + " vitun " + self.getUrbaani())
+            context.bot.sendMessage(chat_id=update.message.chat_id, text=self.getUrbaani().capitalize() + " vitun " + self.getUrbaani())
 
     @banCheck
-    def getVitunSelitys(self, bot, update, args=''):
+    def getVitunSelitys(self, update: Update, context: CallbackContext):
         word = update.message.text[11:].lower().replace(' ', '-').replace('ä', 'a').replace('ö', 'o').replace('å', 'a')
         word = re.sub(r"[^a-z0-9\-]", '', word)
-        bot.sendMessage(chat_id=update.message.chat_id, text=self.getUrbaaniSelitys(word))
+        context.bot.sendMessage(chat_id=update.message.chat_id, text=self.getUrbaaniSelitys(word))
 
     @banCheck
-    def getVaalikone(self, bot, update, args=''):
-        bot.sendMessage(chat_id=update.message.chat_id, text='Äänestä: ' + str(random.randint(1,424) + 1))
+    def getVaalikone(self, update: Update, context: CallbackContext):
+        context.bot.sendMessage(chat_id=update.message.chat_id, text='Äänestä: ' + str(random.randint(1,424) + 1))
 
     @banCheck
-    def getHelveten(self, bot, update, args=''):
-        bot.sendMessage(chat_id=update.message.chat_id,
+    def getHelveten(self, update: Update, context: CallbackContext):
+        context.bot.sendMessage(chat_id=update.message.chat_id,
             text=self.getSlango().capitalize() + ' jävla ' + self.getSlango().lower() )
 
     @banCheck
-    def getTEK(self, bot, update, args=''):
+    def getTEK(self, update: Update, context: CallbackContext):
         if random.randint(0, 50) == 0:
             for word in update.message.text.lower().split(' '):
                 if re.match(r'.*tek.*', word) and word != 'tek':
-                    bot.sendMessage(chat_id=update.message.chat_id, text='ai ' + word.replace('tek', 'TEK') + ' xD')
+                    context.bot.sendMessage(chat_id=update.message.chat_id, text='ai ' + word.replace('tek', 'TEK') + ' xD')
                     return
 
     @banCheck
-    def getTUNI(self, bot, update, args=''):
+    def getTUNI(self, update: Update, context: CallbackContext):
         if random.randint(0, 50) == 0:
             for word in update.message.text.lower().split(' '):
                 if re.match(r'.*tuni.*', word) and word != 'tuni':
-                    bot.sendMessage(chat_id=update.message.chat_id, text='ai ' + word.replace('tuni', 'TUNI') + ' xD')
+                    context.bot.sendMessage(chat_id=update.message.chat_id, text='ai ' + word.replace('tuni', 'TUNI') + ' xD')
                     return
 
     @banCheck
-    def getEnnustus(self, bot, update, args=''):
+    def getEnnustus(self, update: Update, context: CallbackContext):
         now = datetime.datetime.now()
         data = [
             update.message.from_user.id,
@@ -260,10 +267,10 @@ class Teekkari:
         for x in range(n):
             r = rigged.choice(tuple(unicode_codes.EMOJI_UNICODE))
             ennustus += emoji.emojize(r)
-        bot.sendMessage(chat_id=update.message.chat_id, text=ennustus)
+        context.bot.sendMessage(chat_id=update.message.chat_id, text=ennustus)
 
     @banCheck
-    def getUutine(self, bot, update, args=''):
+    def getUutine(self, update: Update, context: CallbackContext):
         now = time.time()
         if self.lastUutineUpdate + 3600 < now:
             self.lastUutineUpdate = now
@@ -280,72 +287,72 @@ class Teekkari:
         if self.nextUutine < now:
             self.nextUutine = now + random.randint(10, 120)
             uutine = random.choice(self.uutineet[0]) + ' – ' + random.choice(self.uutineet[1])
-            bot.sendMessage(chat_id=update.message.chat_id, text=uutine)
+            context.bot.sendMessage(chat_id=update.message.chat_id, text=uutine)
 
     @banCheck
-    def getPottiin(self, bot, update, args=''):
+    def getPottiin(self, update: Update, context: CallbackContext):
         now = datetime.datetime.now().date()
         userId = update.message.from_user.id
         msg = "Pottiin!" if (random.randint(0, 1) == 0) else "kottiin..."
         if userId not in self.lastPottiin:
             self.lastPottiin[userId] = now
-            bot.sendMessage(chat_id=update.message.chat_id, text=msg)
+            context.bot.sendMessage(chat_id=update.message.chat_id, text=msg)
         elif self.lastPottiin[userId] != now:
             self.lastPottiin[userId] = now
-            bot.sendMessage(chat_id=update.message.chat_id, text=msg)
+            context.bot.sendMessage(chat_id=update.message.chat_id, text=msg)
 
     @banCheck
-    def banHammer(self, bot, update, args=''):
+    def banHammer(self, update: Update, context: CallbackContext):
         duration = datetime.datetime.now() + datetime.timedelta(minutes=1)
         print(duration)
-        bot.kickChatMember(update.message.chat.id, update.message.from_user.id, until_date=duration)
+        context.bot.kickChatMember(update.message.chat.id, update.message.from_user.id, until_date=duration)
 
     @banCheck
-    def messageHandler(self, bot, update):
+    def messageHandler(self, update: Update, context: CallbackContext):
         msg = update.message
-        #print(msg)
+
         if msg.text is not None:
             if 'vituttaa' in msg.text.lower():
-                self.getVitutus(bot, update)
+                self.getVitutus(update, context)
             elif 'viisaus' in msg.text.lower():
-                self.getViisaus(bot, update)
+                self.getViisaus(update, context)
             elif 'pekkauotila' in msg.text.lower():
-                self.getVittuilu(bot, update)
+                self.getVittuilu(update, context)
             elif 'hakemus' in msg.text.lower():
-                self.handleHakemus(bot, update)
+                self.handleHakemus(update, context)
             elif 'diagno' in msg.text.lower():
-                self.getDiagnoosi(bot, update)
+                self.getDiagnoosi(update, context)
             elif 'horoskoop' in msg.text.lower():
-                self.getEnnustus(bot, update)
+                self.getEnnustus(update, context)
             elif 'uutine' in msg.text.lower():
-                self.getUutine(bot, update)
+                self.getUutine(update, context)
             elif re.match(r'^halo', msg.text.lower()):
-                self.getHalo(bot, update)
+                self.getHalo(update, context)
             elif re.match(r'^noppa', msg.text.lower()):
-                self.getNoppa(bot, update)
+                self.getNoppa(update, context)
             elif re.match(r'^vaihdan', msg.text.lower()):
-                self.getVaihdan(bot, update)
+                self.getVaihdan(update, context)
             elif re.match(r'^vitun', msg.text.lower()):
-                self.getVitun(bot, update)
+                self.getVitun(update, context)
             elif re.match(r'^mikä vitun ', msg.text.lower()):
-                self.getVitunSelitys(bot, update)
+                self.getVitunSelitys(update, context)
             elif re.match(r'^helveten', msg.text.lower()):
-                self.getHelveten(bot, update)
+                self.getHelveten(update, context)
             elif re.match(r'^/maitonimi', msg.text.lower()):
-                self.getMaitonimi(bot, update)
+                self.getMaitonimi(update, context)
             elif re.match(r'^/lintuslanginimi', msg.text.lower()):
-                self.getLintunimi(bot, update)
+                self.getLintunimi(update, context)
             elif re.match(r'^/kurkkumoponimi', msg.text.lower()):
-                self.getMoponimi(bot, update)
+                self.getMoponimi(update, context)
             elif re.match(r'^/sotanimi', msg.text.lower()):
-                self.getSotanimi(bot, update)
+                self.getSotanimi(update, context)
             elif re.match(r'^/sukunimi', msg.text.lower()):
-                self.getSukunimi(bot, update)
+                self.getSukunimi(update, context)
             elif re.match(r'.*[tT]ek.*', msg.text):
-                self.getTEK(bot, update)
+                self.getTEK(update, context)
             elif re.match(r'.*[tT]uni.*', msg.text):
-                self.getTUNI(bot, update)
+                self.getTUNI(update, context)
             elif 'nakuttaa' in msg.text.lower():
-                self.getNakuttaa(bot, update)
+                self.getNakuttaa(update, context)
             elif re.match(r'^/pottiin', msg.text.lower()):
-                self.getPottiin(bot, update)
+                self.getPottiin(update, context)

--- a/tirsk.py
+++ b/tirsk.py
@@ -1,7 +1,6 @@
 from telegram import Update
 from telegram.ext import CallbackContext
 import random
-from utils import banCheck
 
 class Tirsk:
     isTirsk  = lambda self: random.random() < self.tirsk_prob
@@ -17,7 +16,6 @@ class Tirsk:
         chat_id = update.message.chat.id
         context.bot.sendMessage(chat_id=chat_id, text=self.rndTirsk())
 
-    @banCheck
     def messageHandler(self, update: Update, context: CallbackContext):
         if self.isTirsk():
             self.sendTirsk(update, context)

--- a/tirsk.py
+++ b/tirsk.py
@@ -1,3 +1,5 @@
+from telegram import Update
+from telegram.ext import CallbackContext
 import random
 from utils import banCheck
 
@@ -11,11 +13,11 @@ class Tirsk:
     def getCommands(self):
         return dict()
 
-    def sendTirsk(self, bot, update):
+    def sendTirsk(self, update: Update, context: CallbackContext):
         chat_id = update.message.chat.id
-        bot.sendMessage(chat_id=chat_id, text=self.rndTirsk())
+        context.bot.sendMessage(chat_id=chat_id, text=self.rndTirsk())
 
     @banCheck
-    def messageHandler(self, bot, update):
+    def messageHandler(self, update: Update, context: CallbackContext):
         if self.isTirsk():
-            self.sendTirsk(bot, update)
+            self.sendTirsk(update, context)

--- a/utils.py
+++ b/utils.py
@@ -1,11 +1,3 @@
-from configparser import ConfigParser
-import telegram
-
-cfg = ConfigParser()
-cfg.read('env.cfg')
-
-BANNED_CHANNELS = cfg['TELEGRAM']['banned_channels']
-
 def oppisWithSameText(definitions, text):
     sameDefs = []
     for defin in definitions:
@@ -13,12 +5,3 @@ def oppisWithSameText(definitions, text):
             sameDefs.append(defin[1].lower())
     result = (text, sameDefs)
     return result
-
-def banCheck(func):
-    def checkForBan(*args, **kwargs):
-        if len(args) > 2 and isinstance(args[2], telegram.update.Update):
-            chat_id = str(args[2].message.chat.id)
-            if (chat_id in BANNED_CHANNELS):
-                return
-        return func(*args, **kwargs)
-    return checkForBan

--- a/valitsin.py
+++ b/valitsin.py
@@ -1,3 +1,5 @@
+from telegram import Update
+from telegram.ext import CallbackContext
 import random
 import re
 import datetime
@@ -12,7 +14,7 @@ class Valitsin:
     def getCommands(self):
         return self.commands
 
-    def makeDecision(self, bot, update, alternatives):
+    def makeDecision(self, update: Update, context: CallbackContext, alternatives):
         now = datetime.datetime.now()
         data = [
             update.message.from_user.id,
@@ -25,11 +27,11 @@ class Valitsin:
         rigged = random.Random(seed)
         if rigged.randint(0, 49) == 0:
             answers = ['Molemmat :D', 'Ei kumpaakaan >:(']
-            bot.sendMessage(chat_id=update.message.chat_id, text=rigged.sample(answers, 1)[0])
+            context.bot.sendMessage(chat_id=update.message.chat_id, text=rigged.sample(answers, 1)[0])
         else:
-            bot.sendMessage(chat_id=update.message.chat_id, text=rigged.sample(alternatives, 1)[0])
+            context.bot.sendMessage(chat_id=update.message.chat_id, text=rigged.sample(alternatives, 1)[0])
 
-    def onkoPakko(self, bot, update, groups):
+    def onkoPakko(self, update: Update, context: CallbackContext, groups):
         now = datetime.datetime.now()
         data = [
             update.message.from_user.id,
@@ -41,17 +43,17 @@ class Valitsin:
         seed = hashlib.md5(json.dumps(data, sort_keys=True).encode('utf-8')).hexdigest()
         rigged = random.Random(seed)
         if rigged.randint(0, 1) == 0:
-            bot.sendMessage(chat_id=update.message.chat_id, text='ei ole pakko {}'.format(groups.group(1)))
+            context.bot.sendMessage(chat_id=update.message.chat_id, text='ei ole pakko {}'.format(groups.group(1)))
         else:
-            bot.sendMessage(chat_id=update.message.chat_id, text='on pakko {}'.format(groups.group(1)))
+            context.bot.sendMessage(chat_id=update.message.chat_id, text='on pakko {}'.format(groups.group(1)))
 
     @banCheck
-    def messageHandler(self, bot, update):
+    def messageHandler(self, update: Update, context: CallbackContext):
         msg = update.message
         if msg.text is not None:
             vai = set(msg.text.lower().split()[1::2]) == {'vai'}
             pakko = re.match(r"^onko pakko ([^?]+)(\??)$", msg.text.lower(), re.IGNORECASE)
             if vai:
-                self.makeDecision(bot, update, msg.text.lower().split()[::2])
+                self.makeDecision(update, context, msg.text.lower().split()[::2])
             elif pakko:
-                self.onkoPakko(bot, update, pakko)
+                self.onkoPakko(update, context, pakko)

--- a/valitsin.py
+++ b/valitsin.py
@@ -5,7 +5,6 @@ import re
 import datetime
 import json
 import hashlib
-from utils import banCheck
 
 class Valitsin:
     def __init__(self):
@@ -47,7 +46,6 @@ class Valitsin:
         else:
             context.bot.sendMessage(chat_id=update.message.chat_id, text='on pakko {}'.format(groups.group(1)))
 
-    @banCheck
     def messageHandler(self, update: Update, context: CallbackContext):
         msg = update.message
         if msg.text is not None:


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/6438345/98336183-1ee73800-200f-11eb-81f8-ed6fb9bf8cff.png)

Since `python-telegram-bot` version 12.0 the old handler api has been deprecated and starting up the bot has shown a warning. At version 13.0 (which is out already) the old handler signature is no longer supported, and keeping this bot up to date to support new telegram features as they are released seems very very important.

13.0 version also **drops the support for python 3.5** (as it has reached EOL), and this was tested using python 3.8. Note that you'll have to reinstall/upgrade `python-telegram-bot` module after checking out this branch.

This PR implements the transition to new context based callbacks as defined at https://git.io/fxJuV.

While at it; I made `pylint` happy with the project fixing some unsafe code and minor errors. This made the refactoring much safer, and I would recommend using it in the future too when implementing new features.

Also made `banCheck` much nicer, since remembering to add it everywhere wasn't going to be easy. Now we just register a single filter at `imneversorry.py` for both commands and messages.

I was testing this last night, and seems like everything works. Maybe.