### PR TITLE
Send unique User-Agent to wikipedia and avoid unnecessary GET request

### DIFF
--- a/teekkari.py
+++ b/teekkari.py
@@ -40,6 +40,7 @@ class Teekkari:
             'kalja': self.kippisHandler,
             'nimuli': self.nimuliHandler,
         }
+        self.userAgent = 'Imneversorry/1.0 (http://github.com/Aivoapina/imneversorry)'
         self.vituttaaUrl = 'https://fi.wikipedia.org/wiki/Toiminnot:Satunnainen_sivu'
         self.urbaaniUrl = 'https://urbaanisanakirja.com/random/'
         self.urbaaniWordUrl = 'https://urbaanisanakirja.com/word/'
@@ -142,7 +143,8 @@ class Teekkari:
         await context.bot.sendMessage(chat_id=update.message.chat_id, text=random.sample(self.viisaudet, 1)[0][0])
 
     async def vitutusHandler(self, update: Update, context: CallbackContext):
-        r = requests.get(self.vituttaaUrl, timeout=5)
+        headers = { 'User-Agent': self.userAgent }
+        r = requests.head(self.vituttaaUrl, allow_redirects=True, timeout=5, headers=headers)
         url = urllib.parse.unquote_plus(r.url).split('/')
         vitutus = url[len(url)-1].replace('_', ' ') + " vituttaa"
         await context.bot.sendMessage(chat_id=update.message.chat_id, text=vitutus)


### PR DESCRIPTION
Wikipedia asks clients to identify themselves, https://foundation.wikimedia.org/wiki/Policy:Wikimedia_Foundation_User-Agent_Policy. We haven't been doing that and currently our random page requests fail with 403.

This User-Agent seems to work (and wikipedia could contact us via github issues if our bot misbehaves). There's also no need to do the actual GET request, HEAD is enough since we're just checking the URL where we get redirected from the random page URL.